### PR TITLE
Re-implement update workflow for master version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,8 @@ Install (if not already installed) and use latest master build:
 Update master:
 
 ```
-.\Use-Zig.ps1 master -Install
+.\Use-Zig.ps1 master -Update
 ```
-
-The `-Install` switch basically (re-)installs the specified version, which in
-the case of `master` works like an update, because the latest master
-build will always be downloaded.
 
 ### Example session:
 ```
@@ -43,11 +39,14 @@ Installing Zig (0.7.1) to C:\Users\me\AppData\Local\Zigs\x86_64
 0.7.1
 
 > .\Use-Zig.ps1 master
-Downloading Zig (master) from https://ziglang.org/builds/zig-windows-x86_64-0.8.0-dev.1140+9270aae07.zip
-Installing Zig (master) to C:\Users\me\AppData\Local\Zigs\x86_64
+Downloading Zig (0.8.0-dev.1140+9270aae07) from https://ziglang.org/builds/zig-windows-x86_64-0.8.0-dev.1140+9270aae07.zip
+Installing Zig (0.8.0-dev.1140+9270aae07) to C:\Users\me\AppData\Local\Zigs\x86_64
 
 > zig version
 0.8.0-dev.1140+9270aae07
+
+> Use-Zig.ps1 master -Update
+Version 'master' is already up-to-date
 ```
 
 ## How it works
@@ -62,7 +61,7 @@ installation of the Zig version specified when running the script for the last
 time. This junction is added to the Path environment variable of the current
 shell, so that the Zig executable can be used immediately.
 
-When opening a new shell the script needs to be run once for the junction to
-appear in the Path. You can add the path to the junction to your Path
-environment variable to be able to use a Zig installation immediately in a new
-shell.
+When opening a new shell the script needs to be run once for the junction
+`C:\Users\YOUR_USERNAME\AppData\Local\Zigs\current` to appear in the Path. You
+can add the path to the junction to your Path environment variable to be able
+to use a Zig installation immediately in a new shell.


### PR DESCRIPTION
The master version is used through a junction called
'master' that points to the latest installation of master.
This is different from before where the master intallation
was a simple folder.

This change enables the script to skip update if the latest
version of master is already installed.